### PR TITLE
Refactor home page with modern UI and theme toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,9 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/Pages/Home.js
+++ b/src/Pages/Home.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Link } from 'react-router-dom';
 import Grid from '@mui/material/Grid2';
 
@@ -9,7 +9,9 @@ import { pages } from './';
 
 import {
     MenuRounded,
-    GitHub
+    GitHub,
+    DarkMode,
+    LightMode
 } from '@mui/icons-material';
 
 import {
@@ -17,84 +19,83 @@ import {
     Divider,
     Box,
     Menu,
-    MenuItem
+    MenuItem,
+    AppBar,
+    Toolbar,
+    IconButton,
+    Card,
+    CardContent,
+    CardActions,
+    Button
 } from '@mui/material';
 
-function dropdown(name, options) {
-    const padHeight = '1.5vh';
-    const padWidth  = '3.5vh';
+import { useTheme } from '@mui/material/styles';
+import { ColorModeContext } from '../ThemeContext';
 
+function dropdown(options, handleClose) {
     return (
         <Box>
-            {Object.keys(options).map(text =>
+            {Object.keys(options).map(text => (
                 <MenuItem
-                    sx={{
-                        paddingBottom: padHeight,
-                        paddingTop:    padHeight,
-                        paddingLeft:   padWidth,
-                        paddingRight:  padWidth
-                    }}
                     key={text}
                     component={Link}
-                    to={text.toLowerCase()}>
-                    <Typography
-                        variant='body2'>
-                    {text.replace('_', ' ')}
+                    to={options[text]}
+                    onClick={handleClose}>
+                    <Typography variant='body2'>
+                        {text.replace('_', ' ')}
                     </Typography>
                 </MenuItem>
-            )}
+            ))}
         </Box>
     );
 }
 
-function clickHandler(setAnchor) {
-    return event => {
-        setAnchor(event.currentTarget);
-    };
-}
-
-function closeHandler(setAnchor) {
-    return () => {
-        setAnchor(null);
-    };
-}
-
-function MenuButton({children}) {
-    const [anchor, setAnchor] = useState(null);
-    const handleClick = clickHandler(setAnchor);
-    const handleClose = closeHandler(setAnchor);
-    const open        = Boolean(anchor);
-
-    const define = (value) => {
-        return open ? value : undefined;
-    };
+function Header() {
+    const [anchorEl, setAnchorEl] = useState(null);
+    const open = Boolean(anchorEl);
+    const handleOpen = (event) => setAnchorEl(event.currentTarget);
+    const handleClose = () => setAnchorEl(null);
+    const theme = useTheme();
+    const colorMode = useContext(ColorModeContext);
 
     return (
-        <Box>
-            <TooltipButton
-                title='Menu'
-                id='basic-button'
-                Icon={MenuRounded}
-                aria-controls={define('basic-menu')}
-                aria-expanded={define('true')}
-                aria-haspopup='true'
-                onClick={handleClick} />
+        <>
+            <AppBar position='static' color='transparent' elevation={0}>
+                <Toolbar>
+                    <IconButton
+                        id='navigation-menu-button'
+                        size='large'
+                        edge='start'
+                        color='inherit'
+                        aria-label='open navigation menu'
+                        onClick={handleOpen}>
+                        <MenuRounded />
+                    </IconButton>
+                    <Typography variant='h6' sx={{ flexGrow: 1 }}>
+                        Bangyen
+                    </Typography>
+                    <TooltipButton
+                        href='https://github.com/bangyen'
+                        title='GitHub'
+                        aria-label='GitHub'
+                        Icon={GitHub} />
+                    <TooltipButton
+                        title='Toggle light/dark mode'
+                        aria-label='toggle color mode'
+                        Icon={theme.palette.mode === 'dark' ? LightMode : DarkMode}
+                        onClick={colorMode.toggleColorMode} />
+                </Toolbar>
+            </AppBar>
             <Menu
-                id='basic-menu'
+                anchorEl={anchorEl}
                 open={open}
-                anchorEl={anchor}
-                sx={{
-                    marginLeft: 1,
-                    marginTop: 1
-                }}
                 onClose={handleClose}
-                MenuListProps={{
-                    'aria-labelledby':
-                        'basic-button'
-                }}>
-                {children}
+                MenuListProps={{ 'aria-labelledby': 'navigation-menu-button' }}>
+                {dropdown(pages, handleClose)}
+                <Divider />
+                {dropdown(names, handleClose)}
             </Menu>
-        </Box>
+        </>
     );
 }
 
@@ -104,27 +105,18 @@ function WaveBox({
         height,
         width
     }) {
+    const theme = useTheme();
     const duration = 1;
-    const delay
-        = 5 * index / count;
+    const delay = 5 * index / count;
 
     height = `${height}rem`;
-    width  = `${width}rem`;
+    width = `${width}rem`;
 
-    const animation = `
-        wave
-        ${duration}s
-        ${delay}s
-        ease-in-out
-        infinite
-        alternate
-    `;
+    const animation = `wave ${duration}s ${delay}s ease-in-out infinite alternate`;
 
     const keyframes = {
-        '0%': {transform:
-            'translateY(0)'},
-        '100%': {transform:
-            'translateY(-5rem)'}
+        '0%': { transform: 'translateY(0)' },
+        '100%': { transform: 'translateY(-2rem)' }
     };
 
     return (
@@ -132,91 +124,116 @@ function WaveBox({
             height={height}
             width={width}
             borderRadius={0.5}
-            backgroundColor='white'
             sx={{
                 animation,
-                '@keyframes wave':
-                    keyframes
-            }}>
-        </Box>
+                backgroundColor: theme.palette.primary.light,
+                '@keyframes wave': keyframes
+            }}
+        />
     );
 }
 
 export default function Home() {
+    const theme = useTheme();
     const { width } = useWindow();
-    const date      = Date.now();
+    const date = Date.now();
 
-    const count     = 125;
+    const count = 125;
     const boxHeight = 1.5;
-    const boxWidth  = width / (16 * count);
+    const boxWidth = width / (16 * count);
 
     useEffect(() => {
-        document.title
-            = 'Home | Bangyen';
+        document.title = 'Home | Bangyen';
     }, []);
 
+    const projects = [
+        {
+            title: 'Lights Out',
+            description: 'Puzzle game built with React.',
+            link: pages.Lights_Out,
+        },
+        {
+            title: 'Snake',
+            description: 'Classic Snake game built with React.',
+            link: pages.Snake,
+        },
+    ];
+
     return (
-        <Grid
-            container
-            height="100vh"
-            flexDirection='column'>
-            <Grid
-                container
-                direction="row"
-                margin={2}
-                spacing={2}>
-                <MenuButton>
-                    {dropdown('Miscellaneous', pages)}
-                    <Divider variant='middle' />
-                    {dropdown('Interpreters', names)}
-                </MenuButton>
-                <TooltipButton
-                    href='https://github.com/bangyen'
-                    title='GitHub'
-                    Icon={GitHub} />
-            </Grid>
-            <Grid
-                flex={1}
+        <Box
+            sx={{
+                minHeight: '100vh',
+                position: 'relative',
+                background: `linear-gradient(135deg, ${theme.palette.primary.dark}, ${theme.palette.background.default})`,
+                pb: 10,
+            }}
+        >
+            <Header />
+            <Box
                 display='flex'
+                flexDirection='column'
+                alignItems='center'
                 justifyContent='center'
-                alignItems='center'>
-                <Typography sx={{
+                minHeight='40vh'
+                textAlign='center'
+                mt={4}
+            >
+                <Typography
+                    component='h1'
+                    sx={{
                         typography: {
-                            xs: 'body1',
-                            sm: 'h5',
-                            md: 'h4',
-                            lg: 'h3',
-                            xl: 'h2'
-                        }
-                    }}>
+                            xs: 'h6',
+                            sm: 'h4',
+                            md: 'h3',
+                            lg: 'h2',
+                            xl: 'h1',
+                        },
+                    }}
+                >
                     Hey, my name is&nbsp;
-                    <strong>
-                        Bangyen
-                    </strong>
-                    .
+                    <strong>Bangyen</strong>.
                 </Typography>
+            </Box>
+            <Grid container spacing={2} justifyContent='center' padding={2}>
+                {projects.map((project) => (
+                    <Grid key={project.title} size={{ xs: 12, sm: 6, md: 4 }}>
+                        <Card sx={{ height: '100%' }}>
+                            <CardContent>
+                                <Typography variant='h6' component='h3'>
+                                    {project.title}
+                                </Typography>
+                                <Typography variant='body2' color='text.secondary'>
+                                    {project.description}
+                                </Typography>
+                            </CardContent>
+                            <CardActions>
+                                <Button size='small' component={Link} to={project.link}>
+                                    Explore
+                                </Button>
+                            </CardActions>
+                        </Card>
+                    </Grid>
+                ))}
             </Grid>
-            <Grid
+            <Box
                 left='50%'
-                bottom='10%'
+                bottom='0'
                 width='100%'
                 display='flex'
                 position='absolute'
-                sx={{
-                    transform:
-                        'translateX(-50%)'
-                }}>
-                {[...Array(count)]
-                    .map((_, index) => (
-                        <WaveBox
-                            index={index}
-                            count={count}
-                            key={date + index}
-                            height={boxHeight}
-                            width={boxWidth} />
+                sx={{ transform: 'translateX(-50%)', opacity: 0.3 }}
+            >
+                {[...Array(count)].map((_, index) => (
+                    <WaveBox
+                        index={index}
+                        count={count}
+                        key={date + index}
+                        height={boxHeight}
+                        width={boxWidth}
+                    />
                 ))}
-            </Grid>
-        </Grid>
+            </Box>
+        </Box>
     );
 }
 

--- a/src/ThemeContext.js
+++ b/src/ThemeContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+export const ColorModeContext = createContext({
+    toggleColorMode: () => {},
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import ReactDOM from 'react-dom';
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 
 import {
     HashRouter,
@@ -10,21 +10,10 @@ import {
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { grey, blueGrey } from '@mui/material/colors';
 import { CssBaseline } from '@mui/material';
+import { ColorModeContext } from './ThemeContext';
 
 import * as run from './Interpreters';
 import * as page from './Pages';
-
-const darkTheme = createTheme({
-    palette: {
-        primary: blueGrey,
-        secondary: grey,
-        mode: 'dark',
-    },
-    typography: {
-        fontFamily: 'monospace',
-    },
-});
-
 
 function getRoute(Elem, url) {
     return <Route
@@ -60,12 +49,38 @@ function Website() {
 }
 
 
+function App() {
+    const [mode, setMode] = useState('dark');
+    const colorMode = useMemo(() => ({
+        toggleColorMode: () => {
+            setMode(prev => prev === 'light' ? 'dark' : 'light');
+        },
+    }), []);
+
+    const theme = useMemo(() => createTheme({
+        palette: {
+            primary: blueGrey,
+            secondary: grey,
+            mode,
+        },
+        typography: {
+            fontFamily: 'Inter, sans-serif',
+        },
+    }), [mode]);
+
+    return (
+        <ColorModeContext.Provider value={colorMode}>
+            <ThemeProvider theme={theme}>
+                <CssBaseline />
+                <Website />
+            </ThemeProvider>
+        </ColorModeContext.Provider>
+    );
+}
+
 ReactDOM.render(
     <React.StrictMode>
-        <ThemeProvider theme={darkTheme}>
-            <CssBaseline />
-            <Website />
-        </ThemeProvider>
+        <App />
     </React.StrictMode>,
     document.getElementById('root')
 );


### PR DESCRIPTION
## Summary
- Add global color mode context and theme toggle with Inter font
- Replace custom menu with MUI AppBar toolbar and project cards
- Polish hero section with gradient background and subtle wave animation

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c78e3c74648324802b19af26fc4d04